### PR TITLE
Fix zh locales, again

### DIFF
--- a/Application/Dopamine/zh-CN.lproj/Localizable.strings
+++ b/Application/Dopamine/zh-CN.lproj/Localizable.strings
@@ -11,20 +11,20 @@
 
 // Action Menu
 "Menu_Settings_Title" = "设置";
-"Menu_Restart_SpringBoard_Title" = "注销";
-"Menu_Reboot_Userspace_Title" = "重启用户空间";
+"Menu_Restart_SpringBoard_Title" = "重新启动SpringBoard";
+"Menu_Reboot_Userspace_Title" = "重新启动用户空间";
 "Menu_Credits_Title" = "关于";
 
 // Updating
 "Button_Update" = "更新";
-"Button_Update_Available" = "可更新";
+"Button_Update_Available" = "有更新可用";
 "Button_Update_Environment" = "更新环境";
 
 // Update View
 "Update_Status_Downloading" = "正在下载更新…";
-"Update_Status_Subtitle_Please_Wait" = "请等待完成下载";
+"Update_Status_Subtitle_Please_Wait" = "请等待直至下载完成";
 "Update_Status_Installing" = "正在安装更新…";
-"Update_Status_Subtitle_Restart_Soon" = "设备即将重启";
+"Update_Status_Subtitle_Restart_Soon" = "设备即将重新启动";
 "Title_Changelog" = "更新日志";
 "Changelog_Unavailable_Text" = "更新日志不可用";
 
@@ -35,7 +35,7 @@
 
 // Error View
 "Button_Share" = "分享";
-"Button_Reboot" = "重启";
+"Button_Reboot" = "重新启动";
 
 // Settings Toggles
 "Settings_Tweak_Injection" = "启用插件";
@@ -58,20 +58,20 @@
 "Section_Exploits" = "漏洞利用";
 
 // Settings Alerts
-"Alert_Tweak_Injection_Toggled_Title" = "需要重启用户空间";
-"Alert_Tweak_Injection_Toggled_Body" = "为使变更生效需要重启用户空间，立即执行？";
-"Alert_Tweak_Injection_Toggled_Reboot_Now" = "立刻重启";
-"Alert_Tweak_Injection_Toggled_Reboot_Later" = "稍后重启";
+"Alert_Tweak_Injection_Toggled_Title" = "需要重新启动用户空间";
+"Alert_Tweak_Injection_Toggled_Body" = "需要重新启动用户空间才能应用变更，立即执行？";
+"Alert_Tweak_Injection_Toggled_Reboot_Now" = "重新启动";
+"Alert_Tweak_Injection_Toggled_Reboot_Later" = "以后";
 "Alert_Remove_Jailbreak_Title" = "移除越狱";
-"Alert_Remove_Jailbreak_Pressed_Body" = "「移除越狱」将移除所有和越狱相关的文件，但将保留普通 App、文件、数据。请注意，此操作无法撤销。确认移除越狱吗？";
-"Alert_Remove_Jailbreak_Enabled_Body" = "「移除越狱」将在下次越狱时移除所有和越狱相关的文件，但将保留普通 App、文件、数据。请注意，此操作无法撤销。确认移除越狱吗？";
-"Button_Cancel" = "取消";
+"Alert_Remove_Jailbreak_Pressed_Body" = "「移除越狱」将移除所有和越狱相关的文件，但将保留普通 App、文档及数据。请注意，此操作无法撤销。确认移除越狱吗？";
+"Alert_Remove_Jailbreak_Enabled_Body" = "「移除越狱」将在下次越狱时移除所有和越狱相关的文件，但将保留普通 App、文档及数据。请注意，此操作无法撤销。确认移除越狱吗？";
+"Button_Cancel" = "以后";
 "Button_Continue" = "继续";
 
 // Duplicate Apps Errors
-"Duplicate_Apps_Error_Dopamine_App" = "检测到多个标识符为 \"%@\" 的应用在Dopamine的应用目录中 (\"%@\")，无法继续。";
-"Duplicate_Apps_Error_User_App" = "检测到标识符为 %@ 的应用程序存在于 Dopamines 应用目录中 (\"%@\") 但也单独安装在系统上，无法继续。";
-"Duplicate_Apps_Error_Icon_Cache" = "检测到标识符为 \"%@\" 的应用程序存在于 Dopamine 应用程序目录中 (\"%@\") 但也在不同路径 (\"%@\") 下注册了图标缓存，无法继续。";
+"Duplicate_Apps_Error_Dopamine_App" = "检测到多个标识符为 \"%@\" 的应用在 Dopamine 应用目录中 (\"%@\")，无法继续。";
+"Duplicate_Apps_Error_User_App" = "检测到标识符为 %@ 的应用程序存在于 Dopamines 应用目录中 (\"%@\") ，但其已被单独安装在系统上，无法继续。";
+"Duplicate_Apps_Error_Icon_Cache" = "检测到标识符为 \"%@\" 的应用程序存在于 Dopamine 应用程序目录中 (\"%@\")，但其已在不同路径 (\"%@\") 下注册了图标缓存，无法继续。";
 
 // Settings Lists
 "Theme" = "主题";
@@ -86,20 +86,20 @@
 
 // Logs
 "Initializing Environment" = "初始化环境";
-"Loading BaseBin TrustCache" = "加载 BaseBin TrustCache";
-"Applying Bind Mount" = "应用 Bind Mount";
+"Loading BaseBin TrustCache" = "将基础套件加载至信任缓存（TrustCache）";
+"Applying Bind Mount" = "执行绑定挂载";
 "Removing Jailbreak" = "移除越狱";
 "Elevating Privileges" = "提升权限";
 "Cleaning Up Exploits" = "清理环境";
-"Building Phys R/W Primitive" = "构建 Phys R/W Primitive";
-"Rebooting Userspace" = "重启用户空间";
+"Building Phys R/W Primitive" = "构建硬件读写条件";
+"Rebooting Userspace" = "重新启动用户空间";
 "Patchfinding" = "查找地址";
 "Exploiting Kernel (%@)" = "利用内核漏洞 (%@)";
-"Bypassing PAC (%@)" = "绕过 PAC (%@)";
-"Bypassing PPL (%@)" = "绕过 PPL (%@)";
+"Bypassing PAC (%@)" = "正在绕过 PAC (%@)";
+"Bypassing PPL (%@)" = "正在绕过 PPL (%@)";
 
 // Package Manager selection
-"Status_Title_Select_Package_Managers" = "选择包管理器（越狱商店）";
-"Select_Package_Managers_Install_Message" = "若你不确定如何选择，请使用 Sileo";
+"Status_Title_Select_Package_Managers" = "选择包管理器";
+"Select_Package_Managers_Install_Message" = "若不确定如何选择，请使用 Sileo";
 "Continue" = "继续";
 

--- a/Application/Dopamine/zh-Hans.lproj/Localizable.strings
+++ b/Application/Dopamine/zh-Hans.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"Credits_Made_By" = "作者：opa334, évelyne";
+"Credits_Made_By" = "作者：opa334, évelyne (ElleKit)";
 
 // Log
 "Status_Title_Jailbreaking" = "越狱中";
@@ -7,38 +7,38 @@
 // Jailbreak Button
 "Button_Jailbreak_Title" = "越狱";
 "Status_Title_Jailbroken" = "已越狱";
-/*Unsupported*/
+"Unsupported" = "不支持";
 
 // Action Menu
 "Menu_Settings_Title" = "设置";
-"Menu_Restart_SpringBoard_Title" = "注销";
-"Menu_Reboot_Userspace_Title" = "重启用户空间";
+"Menu_Restart_SpringBoard_Title" = "重新启动SpringBoard";
+"Menu_Reboot_Userspace_Title" = "重新启动用户空间";
 "Menu_Credits_Title" = "关于";
 
 // Updating
 "Button_Update" = "更新";
-"Button_Update_Available" = "可更新";
+"Button_Update_Available" = "有更新可用";
 "Button_Update_Environment" = "更新环境";
 
 // Update View
 "Update_Status_Downloading" = "正在下载更新…";
-"Update_Status_Subtitle_Please_Wait" = "请等待完成下载";
+"Update_Status_Subtitle_Please_Wait" = "请等待直至下载完成";
 "Update_Status_Installing" = "正在安装更新…";
-"Update_Status_Subtitle_Restart_Soon" = "设备即将重启";
-"Title_Changelog" = "变更日志";
-"Changelog_Unavailable_Text" = "变更日志不可用";
+"Update_Status_Subtitle_Restart_Soon" = "设备即将重新启动";
+"Title_Changelog" = "更新日志";
+"Changelog_Unavailable_Text" = "更新日志不可用";
 
 // Removed Jailbreak Alert
-/*Removed_Jailbreak_Alert_Title*/
-/*Removed_Jailbreak_Alert_Message*/
-/*Button_Close*/
+"Removed_Jailbreak_Alert_Title" = "已移除越狱";
+"Removed_Jailbreak_Alert_Message" = "已成功移除越狱，推荐重启手机。";
+"Button_Close" = "关闭";
 
 // Error View
-/*Button_Share*/
-/*Button_Reboot*/
+"Button_Share" = "分享";
+"Button_Reboot" = "重新启动";
 
 // Settings Toggles
-"Settings_Tweak_Injection" = "插件注入";
+"Settings_Tweak_Injection" = "启用插件";
 "Settings_iDownload" = "iDownload (开发者终端)";
 "Settings_Verbose_Logs" = "详细日志";
 
@@ -46,38 +46,38 @@
 "Button_Remove_Jailbreak" = "移除越狱";
 "Button_Hide_Jailbreak" = "隐藏越狱";
 "Button_Unhide_Jailbreak" = "取消隐藏越狱";
-/*Button_Refresh_Jailbreak_Apps*/
+"Button_Refresh_Jailbreak_Apps" = "刷新越狱应用程序";
 "Button_Reinstall_Package_Managers" = "重新安装包管理器";
 
 // Settings Hints
 "Hint_Hide_Jailbreak" = "「隐藏越狱」将在下次越狱前临时移除越狱相关的文件。";
-"Hint_Hide_Jailbreak_Jailbroken" = "在已越狱状态下，「隐藏越狱」将部分禁用越狱功能以提升检测越狱的难度。但是，它并非总是有效，也并没有隐藏所有东西。";
-/*Section_Jailbreak_Settings*/
-/*Section_Actions*/
-/*Section_Customization*/
-/*Section_Exploits*/
+"Hint_Hide_Jailbreak_Jailbroken" = "在已越狱状态下，「隐藏越狱」将部分禁用越狱功能以提升检测越狱的难度。但「隐藏越狱」并不能完全防止应用程序检测到越狱。";
+"Section_Jailbreak_Settings" = "越狱设置";
+"Section_Actions" = "操作";
+"Section_Customization" = "自定义";
+"Section_Exploits" = "漏洞利用";
 
 // Settings Alerts
-/*Alert_Tweak_Injection_Toggled_Title*/
-"Alert_Tweak_Injection_Toggled_Body" = "为使变更生效需要重启用户空间，立即执行？";
-/*Alert_Tweak_Injection_Toggled_Reboot_Now*/
-/*Alert_Tweak_Injection_Toggled_Reboot_Later*/
+"Alert_Tweak_Injection_Toggled_Title" = "需要重新启动用户空间";
+"Alert_Tweak_Injection_Toggled_Body" = "需要重新启动用户空间才能应用变更，立即执行？";
+"Alert_Tweak_Injection_Toggled_Reboot_Now" = "重新启动";
+"Alert_Tweak_Injection_Toggled_Reboot_Later" = "以后";
 "Alert_Remove_Jailbreak_Title" = "移除越狱";
-"Alert_Remove_Jailbreak_Pressed_Body" = "「移除越狱」将移除所有和越狱相关的文件，但将保留普通 App、文件、数据。请注意，此操作无法撤销。确认移除越狱吗？";
-/*Alert_Remove_Jailbreak_Enabled_Body*/
-"Button_Cancel" = "取消";
-"Button_Continue" = "Continue";
+"Alert_Remove_Jailbreak_Pressed_Body" = "「移除越狱」将移除所有和越狱相关的文件，但将保留普通 App、文档及数据。请注意，此操作无法撤销。确认移除越狱吗？";
+"Alert_Remove_Jailbreak_Enabled_Body" = "「移除越狱」将在下次越狱时移除所有和越狱相关的文件，但将保留普通 App、文档及数据。请注意，此操作无法撤销。确认移除越狱吗？";
+"Button_Cancel" = "以后";
+"Button_Continue" = "继续";
 
 // Duplicate Apps Errors
-/*Duplicate_Apps_Error_Dopamine_App*/
-/*Duplicate_Apps_Error_User_App*/
-/*Duplicate_Apps_Error_Icon_Cache*/
+"Duplicate_Apps_Error_Dopamine_App" = "检测到多个标识符为 \"%@\" 的应用在 Dopamine 应用目录中 (\"%@\")，无法继续。";
+"Duplicate_Apps_Error_User_App" = "检测到标识符为 %@ 的应用程序存在于 Dopamines 应用目录中 (\"%@\") ，但其已被单独安装在系统上，无法继续。";
+"Duplicate_Apps_Error_Icon_Cache" = "检测到标识符为 \"%@\" 的应用程序存在于 Dopamine 应用程序目录中 (\"%@\")，但其已在不同路径 (\"%@\") 下注册了图标缓存，无法继续。";
 
 // Settings Lists
-/*Theme*/
-/*Kernel Exploit*/
-/*PPL Bypass*/
-/*PAC Bypass*/
+"Theme" = "主题";
+"Kernel Exploit" = "内核漏洞";
+"PPL Bypass" = "PPL 绕过";
+"PAC Bypass" = "PAC 绕过";
 
 // Credits
 "Credits_Button_Discord" = "Discord";
@@ -86,20 +86,19 @@
 
 // Logs
 "Initializing Environment" = "初始化环境";
-/*Loading BaseBin TrustCache*/
-/*Applying Bind Mount*/
-/*Removing Jailbreak*/
-/*Elevating Privileges*/
-/*Cleaning Up Exploits*/
-/*Building Phys R/W Primitive*/
-/*Rebooting Userspace*/
-"Patchfinding" = "Patchfinding";
-/*Exploiting Kernel (%@)*/
-/*Bypassing PAC (%@)*/
-/*Bypassing PPL (%@)*/
+"Loading BaseBin TrustCache" = "将基础套件加载至信任缓存（TrustCache）";
+"Applying Bind Mount" = "执行绑定挂载";
+"Removing Jailbreak" = "移除越狱";
+"Elevating Privileges" = "提升权限";
+"Cleaning Up Exploits" = "清理环境";
+"Building Phys R/W Primitive" = "构建硬件读写条件";
+"Rebooting Userspace" = "重新启动用户空间";
+"Patchfinding" = "查找地址";
+"Exploiting Kernel (%@)" = "利用内核漏洞 (%@)";
+"Bypassing PAC (%@)" = "正在绕过 PAC (%@)";
+"Bypassing PPL (%@)" = "正在绕过 PPL (%@)";
 
 // Package Manager selection
-"Status_Title_Select_Package_Managers" = "选择包管理器（越狱商店）";
-"Select_Package_Managers_Install_Message" = "若你不确定如何选择，请使用 Sileo";
+"Status_Title_Select_Package_Managers" = "选择包管理器";
+"Select_Package_Managers_Install_Message" = "若不确定如何选择，请使用 Sileo";
 "Continue" = "继续";
-


### PR DESCRIPTION
Grammar/Noun/Semantic fixes
- Removed misleading translations ("越狱商店", "注销", etc.)
- Correct or translate terms/nouns ("TrustCache" => "信任缓存", etc.)
- Apple-like translations ("重启" => "重新启动", "取消" => "以后", etc.)
- Other minor changes